### PR TITLE
fix: поправляет размер кнопки

### DIFF
--- a/blocks/button/button.css
+++ b/blocks/button/button.css
@@ -18,6 +18,7 @@
   padding: calc(12px - 2px) calc(16px - 2px);
   text-decoration: none;
   transition: all 0.1s ease-in-out;
+  width: fit-content;
 }
 
 .button:hover:not(:disabled) {


### PR DESCRIPTION
В блоках с неограниченной шириной кнопки могли занимать всю ширину.